### PR TITLE
Fix  Rust sui-order-signing example compile error (#14)

### DIFF
--- a/rust-examples/sui-order-signing/src/order.rs
+++ b/rust-examples/sui-order-signing/src/order.rs
@@ -65,7 +65,6 @@ pub fn decimal_to_bcs(num: u64) -> Vec<u8>{
             bcs_byte |= 0x80;
         }
         bcs_bytes.push(bcs_byte as u8);
-        bcs_bytes.push(bcs_byte);
 
         temp_num >>= 7;
 


### PR DESCRIPTION
```
error[E0308]: mismatched types
    --> src/order.rs:68:24
     |
68   |         bcs_bytes.push(bcs_byte);
     |                   ---- ^^^^^^^^ expected `u8`, found `u64`
     |                   |
     |                   arguments to this method are incorrect
```

https://github.com/fireflyprotocol/signing-examples/blob/b78eb39bf7d89453f04a08deb173fec7b7c6dfe0/rust-examples/sui-order-signing/src/order.rs#L67-L68

the line `bcs_bytes.push(bcs_byte);` is duplicate and redundant, I delete this line in my PR